### PR TITLE
Request context

### DIFF
--- a/src/test/java/io/opentracing/contrib/examples/request_context/CustomActiveSpanSource.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/CustomActiveSpanSource.java
@@ -1,0 +1,166 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.ActiveSpanSource;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * If we create a wrapper for ActiveSpanSource then we won't able to obtain underlying Span inside
+ * ActiveSpanSource.activeSpan. That's why wrapper is insufficient, we need our own implementation :(
+ * <p>
+ * Would be nice to reuse ThreadLocalActiveSpan but it sits in another package and has package protected constructor :(((
+ * <p>
+ * I've just copied here whole implementation of ThreadLocalActiveSpan and made it expose underlying Span.
+ */
+public class CustomActiveSpanSource implements ActiveSpanSource {
+    final ThreadLocal<ThreadLocalActiveSpanCopy> tlsSnapshot = new ThreadLocal<ThreadLocalActiveSpanCopy>();
+
+    @Override
+    public ThreadLocalActiveSpanCopy activeSpan() {
+        return tlsSnapshot.get();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        // This is too late, Tracer should create WrappedSpans, not active span source!
+        WrappedSpan wrapped = new WrappedSpan(span, null);
+        return new ThreadLocalActiveSpanCopy(this, wrapped, new AtomicInteger(1));
+    }
+
+    /**
+     * Like normal ThreadLocalActiveSpan but has getWrapped() method.
+     */
+    static class ThreadLocalActiveSpanCopy implements ActiveSpan {
+        private final CustomActiveSpanSource source;
+        private final Span wrapped;
+        private final ThreadLocalActiveSpanCopy toRestore;
+        private final AtomicInteger refCount;
+
+        ThreadLocalActiveSpanCopy(CustomActiveSpanSource source, Span wrapped, AtomicInteger refCount) {
+            this.source = source;
+            this.refCount = refCount;
+            this.wrapped = wrapped;
+            this.toRestore = source.tlsSnapshot.get();
+            source.tlsSnapshot.set(this);
+        }
+
+        public Span getWrapped() {
+            return wrapped;
+        }
+
+        @Override
+        public void deactivate() {
+            if (source.tlsSnapshot.get() != this) {
+                // This shouldn't happen if users call methods in the expected order. Bail out.
+                return;
+            }
+            source.tlsSnapshot.set(toRestore);
+
+            if (0 == refCount.decrementAndGet()) {
+                wrapped.finish();
+            }
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy.Continuation capture() {
+            return new ThreadLocalActiveSpanCopy.Continuation();
+        }
+
+        @Override
+        public SpanContext context() {
+            return wrapped.context();
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy setTag(String key, String value) {
+            wrapped.setTag(key, value);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy setTag(String key, boolean value) {
+            wrapped.setTag(key, value);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy setTag(String key, Number value) {
+            wrapped.setTag(key, value);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(Map<String, ?> fields) {
+            wrapped.log(fields);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(long timestampMicroseconds, Map<String, ?> fields) {
+            wrapped.log(timestampMicroseconds, fields);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(String event) {
+            wrapped.log(event);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(long timestampMicroseconds, String event) {
+            wrapped.log(timestampMicroseconds, event);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy setBaggageItem(String key, String value) {
+            wrapped.setBaggageItem(key, value);
+            return this;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return wrapped.getBaggageItem(key);
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy setOperationName(String operationName) {
+            wrapped.setOperationName(operationName);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(String eventName, Object payload) {
+            wrapped.log(eventName, payload);
+            return this;
+        }
+
+        @Override
+        public ThreadLocalActiveSpanCopy log(long timestampMicroseconds, String eventName, Object payload) {
+            wrapped.log(timestampMicroseconds, eventName, payload);
+            return this;
+        }
+
+        @Override
+        public void close() {
+            deactivate();
+        }
+
+        private final class Continuation implements ActiveSpan.Continuation {
+            Continuation() {
+                refCount.incrementAndGet();
+            }
+
+            @Override
+            public ThreadLocalActiveSpanCopy activate() {
+                return new ThreadLocalActiveSpanCopy(source, wrapped, refCount);
+            }
+        }
+
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/RequestContext.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/RequestContext.java
@@ -1,0 +1,61 @@
+package io.opentracing.contrib.examples.request_context;
+
+
+import io.opentracing.Tracer;
+
+import java.util.Map;
+
+import static io.opentracing.contrib.examples.request_context.CustomActiveSpanSource.ThreadLocalActiveSpanCopy;
+
+/**
+ * A baggage-like context, but can hold any type of value and it not propagated outside of the process.
+ * <p>
+ * There are few ways to implement this. The main issue is how to kep track of the relation between context map and
+ * a Span when Spans have no identity guaranteed by the API. I see following options:
+ * 1. Wrap ActiveSpanSource, maybe also ActiveSpan/Span and provide identity
+ * 2. Wrap Span and store the context inside it
+ * <p>
+ * If we go with 1. then we as well can do 2., so this implements the 2nd approach.
+ * <p>
+ * Both approaches (adding context map or identity to span) have a drawback though - we will need to downcast to our
+ * WrappedSpan. If the span is wrapped with another wrapper the casting will fail.
+ * <p>
+ * But! That's not all. We need to obtain our current (active) WrappedSpan. But ActiveSpan does not provide such method.
+ * So we also need to wrap ActiveSpan to add a method returning the span :(
+ */
+public class RequestContext {
+    private final Tracer tracer;
+
+    public RequestContext(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public <T> T get(String key, Class<T> valueClass) {
+        Map<String, Object> context = getContext();
+        if (context == null) {
+            return null;
+        }
+
+        //noinspection unchecked
+        return (T) context.get(key);
+    }
+
+    public void put(String key, Object value) {
+        Map<String, Object> context = getContext();
+        if (context != null) {
+            context.put(key, value);
+        }
+    }
+
+    private Map<String, Object> getContext() {
+        // !! this works only with our custom active span source!
+        ThreadLocalActiveSpanCopy activeSpan = (ThreadLocalActiveSpanCopy) tracer.activeSpan();
+        if (activeSpan != null) {
+
+            // !! this works with only our span wrapper, other wrappers will break it
+            WrappedSpan wrapped = (WrappedSpan) activeSpan.getWrapped();
+            return wrapped.getRequestContext();
+        }
+        return null;
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/RequestContextTest.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/RequestContextTest.java
@@ -1,0 +1,110 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.opentracing.ActiveSpan.Continuation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RequestContextTest {
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    @Test
+    public void singleSpan() {
+        Tracer tracer = new TracerWrapper(new MockTracer(new CustomActiveSpanSource(), MockTracer.Propagator.TEXT_MAP));
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (ActiveSpan span = tracer.buildSpan("x").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            User user = ctx.get("current_user", User.class);
+
+            assertEquals("john", user.name);
+        }
+    }
+
+    @Test
+    public void propagatesToChildSpans() {
+        Tracer tracer = new TracerWrapper(new MockTracer(new CustomActiveSpanSource(), MockTracer.Propagator.TEXT_MAP));
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            try (ActiveSpan child = tracer.buildSpan("child")
+                    .asChildOf(parent) // explicit because MockTracer does not add this automatically
+                    .startActive()) {
+                User user = ctx.get("current_user", User.class);
+
+                assertEquals("john", user.name);
+            }
+        }
+    }
+
+    @Test
+    public void changesInChildSpansDoNotAlterParent() {
+        Tracer tracer = new TracerWrapper(new MockTracer(new CustomActiveSpanSource(), MockTracer.Propagator.TEXT_MAP));
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            try (ActiveSpan child = tracer.buildSpan("child").startActive()) {
+                ctx.put("current_user", new User(2, "bob"));
+            }
+
+            assertEquals(ctx.get("current_user", User.class).name, "john");
+        }
+    }
+
+    @Test
+    public void keysSetInChildNotVisibleInParent() {
+        Tracer tracer = new TracerWrapper(new MockTracer(new CustomActiveSpanSource(), MockTracer.Propagator.TEXT_MAP));
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+            try (ActiveSpan child = tracer.buildSpan("child").startActive()) {
+                ctx.put("current_user", new User(2, "bob"));
+            }
+            assertNull(ctx.get("current_user", User.class));
+        }
+    }
+
+    @Test
+    public void propagatesToOtherThreads() throws Exception {
+        Tracer tracer = new TracerWrapper(new MockTracer(new CustomActiveSpanSource(), MockTracer.Propagator.TEXT_MAP));
+        final RequestContext ctx = new RequestContext(tracer);
+        final AtomicReference<User> threadUser = new AtomicReference<>();
+        try (ActiveSpan span = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+            final Continuation continuation = span.capture();
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try (ActiveSpan span2 = continuation.activate()) {
+                        threadUser.set(ctx.get("current_user", User.class));
+                    }
+                }
+            }).get();
+
+            assertEquals(threadUser.get().name, "john");
+        }
+    }
+
+    static class User {
+        int id;
+        String name;
+
+        User(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
@@ -15,8 +15,8 @@ import static io.opentracing.contrib.examples.request_context.CustomActiveSpanSo
  * Note2 - startActive starts a span but returns active span. We assume that the wrapped SpanBuilder will call
  * startManual first (so that we can wrap the span) and then makeActive()
  * <p>
- * Note3 - unfortunately we can't wrap startManual properly as the wrapped tracer calls it's own (not wrapped) startManual. Which sucks.
- * That's why one test does not pass.
+ * Note3 - unfortunately we can't wrap startManual properly as the wrapped tracer calls it's own (not wrapped) startManual.
+ * That's why startActive has this weird code.
  */
 public class SpanBuilderWrapper implements Tracer.SpanBuilder {
     private final Tracer.SpanBuilder wrapped;

--- a/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
@@ -1,0 +1,108 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.opentracing.contrib.examples.request_context.CustomActiveSpanSource.ThreadLocalActiveSpanCopy;
+
+/**
+ * SpanBuilder which creates Spans with RequestContext. Propagates RequestContext from parent span to child.
+ * <p>
+ * Note1 - it works only when calling asChildOf(BaseSpan). asChildOf(SpanContext) has no way to obtain
+ * parent's RequestContext.
+ * <p>
+ * Note2 - startActive starts a span but returns active span. We assume that the wrapped SpanBuilder will call
+ * startManual first (so that we can wrap the span) and then makeActive()
+ * <p>
+ * Note3 - unfortunately we can't wrap startManual properly as the wrapped tracer calls it's own (not wrapped) startManual. Which sucks.
+ * That's why one test does not pass.
+ */
+public class SpanBuilderWrapper implements Tracer.SpanBuilder {
+    private final Tracer.SpanBuilder wrapped;
+    private ConcurrentHashMap<String, Object> withRequestContext;
+
+    public SpanBuilderWrapper(Tracer.SpanBuilder wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+        // this is a hack because wrapped Tracer calls it's own startManual, not startManual from this class
+        // so we add parent request context values explicitly here
+        ThreadLocalActiveSpanCopy activeSpan = (ThreadLocalActiveSpanCopy) wrapped.startActive();
+        WrappedSpan wrapped = (WrappedSpan) activeSpan.getWrapped();
+        if(withRequestContext != null) {
+            wrapped.getRequestContext().putAll(withRequestContext);
+        }
+        return activeSpan;
+    }
+
+    @Override
+    public Span startManual() {
+        return new WrappedSpan(wrapped.startManual(), withRequestContext);
+    }
+
+    @Override
+    @Deprecated
+    public Span start() {
+        return new WrappedSpan(wrapped.start(), withRequestContext);
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+        wrapped.asChildOf(parent);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(BaseSpan<?> parent) {
+        WrappedSpan parentWrapped;
+        if (parent instanceof ThreadLocalActiveSpanCopy) {
+            ThreadLocalActiveSpanCopy parentActiveSpan = (ThreadLocalActiveSpanCopy) parent;
+            parentWrapped = (WrappedSpan) parentActiveSpan.getWrapped();
+        } else {
+            parentWrapped = (WrappedSpan) parent;
+        }
+        // copy request context from parent
+        withRequestContext = new ConcurrentHashMap<>(parentWrapped.getRequestContext());
+        wrapped.asChildOf(parent);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+        wrapped.addReference(referenceType, referencedContext);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder ignoreActiveSpan() {
+        wrapped.ignoreActiveSpan();
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, String value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, boolean value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, Number value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        wrapped.withStartTimestamp(microseconds);
+        return this;
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/TracerWrapper.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/TracerWrapper.java
@@ -1,0 +1,40 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+public class TracerWrapper implements Tracer {
+    private final Tracer wrapped;
+
+    public TracerWrapper(Tracer wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilderWrapper(wrapped.buildSpan(operationName));
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        wrapped.inject(spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return wrapped.extract(format, carrier);
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return wrapped.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return wrapped.makeActive(span);
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/WrappedSpan.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/WrappedSpan.java
@@ -1,0 +1,102 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WrappedSpan implements Span {
+    private final Span wrapped;
+    private Map<String, Object> requestContext;
+
+    public WrappedSpan(Span wrapped, ConcurrentHashMap<String, Object> requestContext) {
+        this.wrapped = wrapped;
+        if (requestContext != null) {
+            this.requestContext = requestContext;
+        } else {
+            this.requestContext = new ConcurrentHashMap<>();
+        }
+    }
+
+    public Map<String, Object> getRequestContext() {
+        return requestContext;
+    }
+
+    @Override
+    public void finish() {
+        wrapped.finish();
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+        wrapped.finish(finishMicros);
+    }
+
+    @Override
+    public SpanContext context() {
+        return wrapped.context();
+    }
+
+    @Override
+    public Span setTag(String key, String value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span setTag(String key, boolean value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span setTag(String key, Number value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span log(Map<String, ?> fields) {
+        return wrapped.log(fields);
+    }
+
+    @Override
+    public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+        return wrapped.log(timestampMicroseconds, fields);
+    }
+
+    @Override
+    public Span log(String event) {
+        return wrapped.log(event);
+    }
+
+    @Override
+    public Span log(long timestampMicroseconds, String event) {
+        return wrapped.log(timestampMicroseconds, event);
+    }
+
+    @Override
+    public Span setBaggageItem(String key, String value) {
+        return wrapped.setBaggageItem(key, value);
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return wrapped.getBaggageItem(key);
+    }
+
+    @Override
+    public Span setOperationName(String operationName) {
+        return wrapped.setOperationName(operationName);
+    }
+
+    @Override
+    @Deprecated
+    public Span log(String eventName, Object payload) {
+        return wrapped.log(eventName, payload);
+    }
+
+    @Override
+    @Deprecated
+    public Span log(long timestampMicroseconds, String eventName, Object payload) {
+        return wrapped.log(timestampMicroseconds, eventName, payload);
+    }
+}


### PR DESCRIPTION
This is an attempt to implement request context - a baggage-like construct which:
- is propagated to child spans, but not outside of the process
- is copied when propagating so changes in child spans do not affect values in the parent span
- can hold arbitrary objects, not only strings

The tests pass but the code looks terrible, a lot of wrapping and downcasting is going on.

I've added comments pointing problems.

The basic idea is to have a way to assign Map<String, Object> (let's call it Context) to each span. If spans had some unique id then we could use this id and just keep a Map<SpanId, Context>. But they do not have id and even `equals()` behaviour is not defined (and won't work with all these wrappers from various libs).
So another approach is to basically add this `Context` to the `Span` itself - and create wrappers for almost everything. This is what this PR shows.

Probably it would be simpler if there was a way to register listeners for important events - like span creation, especially if wrappers were not required.