### PR TITLE
Request context for Scopes [do not merge]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <opentracing.version>0.30.0</opentracing.version>
+    <opentracing.version>0.30.1-SNAPSHOT</opentracing.version>
   </properties>
 
   <dependencies>

--- a/src/test/java/io/opentracing/contrib/examples/activate_deactivate/Callback.java
+++ b/src/test/java/io/opentracing/contrib/examples/activate_deactivate/Callback.java
@@ -1,50 +1,50 @@
-package io.opentracing.contrib.examples.activate_deactivate;
-
-import io.opentracing.Scope;
-import io.opentracing.usecases.AutoFinishScopeManager;
-import io.opentracing.usecases.AutoFinishScopeManager.AutoFinishScope;
-import io.opentracing.tag.Tags;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-/**
- * Callback which executed at some unpredictable time. We don't know when it is started, when it is
- * completed. We cannot check status of it (started or completed)
- */
-public class Callback implements Runnable {
-
-  private static final Logger logger = LoggerFactory.getLogger(Callback.class);
-
-  private final Random random = new Random();
-
-  private final AutoFinishScope.Continuation continuation;
-
-  Callback(Scope activeSpan) {
-    continuation = ((AutoFinishScope)activeSpan).defer();
-    logger.info("Callback created");
-  }
-
-  /**
-   * Can be used continuation.activate().deactivate() chain only. It is splitted for testing
-   * purposes (span should not be finished before deactivate() called here).
-   */
-  @Override
-  public void run() {
-    logger.info("Callback started");
-
-    Scope scope = continuation.activate();
-    try {
-      TimeUnit.SECONDS.sleep(1);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-
-    // set random tag starting with 'test_tag_' to test that finished span has all of them
-    scope.span().setTag("test_tag_" + random.nextInt(), "random");
-
-    scope.close();
-    logger.info("Callback finished");
-  }
-}
+//package io.opentracing.contrib.examples.activate_deactivate;
+//
+//import io.opentracing.Scope;
+//import io.opentracing.usecases.AutoFinishScopeManager;
+//import io.opentracing.usecases.AutoFinishScopeManager.AutoFinishScope;
+//import io.opentracing.tag.Tags;
+//import java.util.Random;
+//import java.util.concurrent.TimeUnit;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+///**
+// * Callback which executed at some unpredictable time. We don't know when it is started, when it is
+// * completed. We cannot check status of it (started or completed)
+// */
+//public class Callback implements Runnable {
+//
+//  private static final Logger logger = LoggerFactory.getLogger(Callback.class);
+//
+//  private final Random random = new Random();
+//
+//  private final AutoFinishScope.Continuation continuation;
+//
+//  Callback(Scope activeSpan) {
+//    continuation = ((AutoFinishScope)activeSpan).defer();
+//    logger.info("Callback created");
+//  }
+//
+//  /**
+//   * Can be used continuation.activate().deactivate() chain only. It is splitted for testing
+//   * purposes (span should not be finished before deactivate() called here).
+//   */
+//  @Override
+//  public void run() {
+//    logger.info("Callback started");
+//
+//    Scope scope = continuation.activate();
+//    try {
+//      TimeUnit.SECONDS.sleep(1);
+//    } catch (InterruptedException e) {
+//      e.printStackTrace();
+//    }
+//
+//    // set random tag starting with 'test_tag_' to test that finished span has all of them
+//    scope.span().setTag("test_tag_" + random.nextInt(), "random");
+//
+//    scope.close();
+//    logger.info("Callback finished");
+//  }
+//}

--- a/src/test/java/io/opentracing/contrib/examples/activate_deactivate/TestCallback.java
+++ b/src/test/java/io/opentracing/contrib/examples/activate_deactivate/TestCallback.java
@@ -1,125 +1,125 @@
-package io.opentracing.contrib.examples.activate_deactivate;
-
-import static com.jayway.awaitility.Awaitility.await;
-import static io.opentracing.contrib.examples.TestUtils.reportedSpansSize;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-
-import io.opentracing.Scope;
-import io.opentracing.Scope.Observer;
-import io.opentracing.mock.MockSpan;
-import io.opentracing.mock.MockTracer;
-import io.opentracing.mock.MockTracer.Propagator;
-import io.opentracing.tag.Tags;
-import io.opentracing.usecases.AutoFinishScopeManager;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class TestCallback {
-
-  private static final Logger logger = LoggerFactory.getLogger(TestCallback.class);
-
-  private final MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);
-  private final ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
-
-  @Before
-  public void before() {
-    tracer.reset();
-    tracer.setScopeManager(new AutoFinishScopeManager());
-  }
-
-  @Test
-  public void test() throws Exception {
-    Thread entryThread = entryThread();
-    entryThread.start();
-    entryThread.join(10_000);
-    // Entry thread is completed but Callback is still running (or even not started)
-
-    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(1));
-
-    List<MockSpan> finished = tracer.finishedSpans();
-    assertEquals(1, finished.size());
-
-    assertEquals(1, getTestTagsCount(finished.get(0)));
-  }
-
-  @Test
-  public void test_two_callbacks() throws Exception {
-    Thread entryThread = entryThreadWithTwoCallbacks();
-    entryThread.start();
-    entryThread.join(10_000);
-    // Entry thread is completed but Callbacks are still running (or even not started)
-
-    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(1));
-
-    List<MockSpan> finished = tracer.finishedSpans();
-    assertEquals(1, finished.size());
-
-    // Check that two callbacks finished and each added to span own tag ('test_tag_{random}')
-    assertEquals(2, getTestTagsCount(finished.get(0)));
-  }
-
-  private int getTestTagsCount(MockSpan mockSpan) {
-    Map<String, Object> tags = mockSpan.tags();
-    int tagCounter = 0;
-    for (String tagKey : tags.keySet()) {
-      if (tagKey.startsWith("test_tag_")) {
-        tagCounter++;
-      }
-    }
-    return tagCounter;
-  }
-
-  /**
-   * Thread will be completed before callback completed.
-   */
-  private Thread entryThread() {
-    return new Thread(new Runnable() {
-      @Override
-      public void run() {
-        logger.info("Entry thread started");
-
-        try (Scope scope = tracer.buildSpan("parent").startActive()) {
-          Runnable callback = new Callback(scope);
-
-          // Callback is executed at some unpredictable time and we are not able to check status of the callback
-          service.schedule(callback, 500, TimeUnit.MILLISECONDS);
-        }
-
-        logger.info("Entry thread finished");
-      }
-    });
-  }
-
-  /**
-   * Thread will be completed before callback completed.
-   */
-  private Thread entryThreadWithTwoCallbacks() {
-    return new Thread(new Runnable() {
-      @Override
-      public void run() {
-        logger.info("Entry thread 2x started");
-        try (Scope scope = tracer.buildSpan("parent").startActive()) {
-          Runnable callback = new Callback(scope);
-          Runnable callback2 = new Callback(scope);
-
-          Random random = new Random();
-
-          // Callbacks are executed at some unpredictable time
-          service.schedule(callback, random.nextInt(1000) + 100, TimeUnit.MILLISECONDS);
-          service.schedule(callback2, random.nextInt(1000) + 100, TimeUnit.MILLISECONDS);
-
-        }
-        logger.info("Entry thread 2x finished");
-      }
-    });
-  }
-}
+//package io.opentracing.contrib.examples.activate_deactivate;
+//
+//import static com.jayway.awaitility.Awaitility.await;
+//import static io.opentracing.contrib.examples.TestUtils.reportedSpansSize;
+//import static org.hamcrest.core.IsEqual.equalTo;
+//import static org.junit.Assert.assertEquals;
+//
+//import io.opentracing.Scope;
+//import io.opentracing.Scope.Observer;
+//import io.opentracing.mock.MockSpan;
+//import io.opentracing.mock.MockTracer;
+//import io.opentracing.mock.MockTracer.Propagator;
+//import io.opentracing.tag.Tags;
+//import io.opentracing.usecases.AutoFinishScopeManager;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Random;
+//import java.util.concurrent.Executors;
+//import java.util.concurrent.ScheduledExecutorService;
+//import java.util.concurrent.TimeUnit;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//public class TestCallback {
+//
+//  private static final Logger logger = LoggerFactory.getLogger(TestCallback.class);
+//
+//  private final MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);
+//  private final ScheduledExecutorService service = Executors.newScheduledThreadPool(1);
+//
+//  @Before
+//  public void before() {
+//    tracer.reset();
+//    tracer.setScopeManager(new AutoFinishScopeManager());
+//  }
+//
+//  @Test
+//  public void test() throws Exception {
+//    Thread entryThread = entryThread();
+//    entryThread.start();
+//    entryThread.join(10_000);
+//    // Entry thread is completed but Callback is still running (or even not started)
+//
+//    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(1));
+//
+//    List<MockSpan> finished = tracer.finishedSpans();
+//    assertEquals(1, finished.size());
+//
+//    assertEquals(1, getTestTagsCount(finished.get(0)));
+//  }
+//
+//  @Test
+//  public void test_two_callbacks() throws Exception {
+//    Thread entryThread = entryThreadWithTwoCallbacks();
+//    entryThread.start();
+//    entryThread.join(10_000);
+//    // Entry thread is completed but Callbacks are still running (or even not started)
+//
+//    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(1));
+//
+//    List<MockSpan> finished = tracer.finishedSpans();
+//    assertEquals(1, finished.size());
+//
+//    // Check that two callbacks finished and each added to span own tag ('test_tag_{random}')
+//    assertEquals(2, getTestTagsCount(finished.get(0)));
+//  }
+//
+//  private int getTestTagsCount(MockSpan mockSpan) {
+//    Map<String, Object> tags = mockSpan.tags();
+//    int tagCounter = 0;
+//    for (String tagKey : tags.keySet()) {
+//      if (tagKey.startsWith("test_tag_")) {
+//        tagCounter++;
+//      }
+//    }
+//    return tagCounter;
+//  }
+//
+//  /**
+//   * Thread will be completed before callback completed.
+//   */
+//  private Thread entryThread() {
+//    return new Thread(new Runnable() {
+//      @Override
+//      public void run() {
+//        logger.info("Entry thread started");
+//
+//        try (Scope scope = tracer.buildSpan("parent").startActive()) {
+//          Runnable callback = new Callback(scope);
+//
+//          // Callback is executed at some unpredictable time and we are not able to check status of the callback
+//          service.schedule(callback, 500, TimeUnit.MILLISECONDS);
+//        }
+//
+//        logger.info("Entry thread finished");
+//      }
+//    });
+//  }
+//
+//  /**
+//   * Thread will be completed before callback completed.
+//   */
+//  private Thread entryThreadWithTwoCallbacks() {
+//    return new Thread(new Runnable() {
+//      @Override
+//      public void run() {
+//        logger.info("Entry thread 2x started");
+//        try (Scope scope = tracer.buildSpan("parent").startActive()) {
+//          Runnable callback = new Callback(scope);
+//          Runnable callback2 = new Callback(scope);
+//
+//          Random random = new Random();
+//
+//          // Callbacks are executed at some unpredictable time
+//          service.schedule(callback, random.nextInt(1000) + 100, TimeUnit.MILLISECONDS);
+//          service.schedule(callback2, random.nextInt(1000) + 100, TimeUnit.MILLISECONDS);
+//
+//        }
+//        logger.info("Entry thread 2x finished");
+//      }
+//    });
+//  }
+//}

--- a/src/test/java/io/opentracing/contrib/examples/multiple_callbacks/Client.java
+++ b/src/test/java/io/opentracing/contrib/examples/multiple_callbacks/Client.java
@@ -1,47 +1,47 @@
-package io.opentracing.contrib.examples.multiple_callbacks;
-
-import static io.opentracing.contrib.examples.TestUtils.sleep;
-
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.usecases.AutoFinishScopeManager.AutoFinishScope;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
-
-public class Client {
-
-  private static final Logger logger = LoggerFactory.getLogger(Client.class);
-
-  private final ExecutorService executor = Executors.newCachedThreadPool();
-  private final Tracer tracer;
-
-  public Client(Tracer tracer) {
-    this.tracer = tracer;
-  }
-
-  public Future<Object> send(final Object message, final Scope parentScope, final long milliseconds) {
-    final AutoFinishScope.Continuation cont = ((AutoFinishScope)parentScope).defer();
-
-    return executor.submit(new Callable<Object>() {
-      @Override
-      public Object call() throws Exception {
-        logger.info("Child thread with message '{}' started", message);
-
-        try (Scope parentScope = cont.activate()) {
-          try (Scope scope = tracer.buildSpan("subtask").startActive()) {
-            // Simulate work.
-            sleep(milliseconds);
-          }
-        }
-
-        logger.info("Child thread with message '{}' finished", message);
-        return message + "::response";
-      }
-    });
-  }
-}
+//package io.opentracing.contrib.examples.multiple_callbacks;
+//
+//import static io.opentracing.contrib.examples.TestUtils.sleep;
+//
+//import io.opentracing.Scope;
+//import io.opentracing.Span;
+//import io.opentracing.Tracer;
+//import io.opentracing.usecases.AutoFinishScopeManager.AutoFinishScope;
+//import java.util.concurrent.Callable;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import java.util.concurrent.Future;
+//import org.slf4j.LoggerFactory;
+//import org.slf4j.Logger;
+//
+//public class Client {
+//
+//  private static final Logger logger = LoggerFactory.getLogger(Client.class);
+//
+//  private final ExecutorService executor = Executors.newCachedThreadPool();
+//  private final Tracer tracer;
+//
+//  public Client(Tracer tracer) {
+//    this.tracer = tracer;
+//  }
+//
+//  public Future<Object> send(final Object message, final Scope parentScope, final long milliseconds) {
+//    final AutoFinishScope.Continuation cont = ((AutoFinishScope)parentScope).defer();
+//
+//    return executor.submit(new Callable<Object>() {
+//      @Override
+//      public Object call() throws Exception {
+//        logger.info("Child thread with message '{}' started", message);
+//
+//        try (Scope parentScope = cont.activate()) {
+//          try (Scope scope = tracer.buildSpan("subtask").startActive()) {
+//            // Simulate work.
+//            sleep(milliseconds);
+//          }
+//        }
+//
+//        logger.info("Child thread with message '{}' finished", message);
+//        return message + "::response";
+//      }
+//    });
+//  }
+//}

--- a/src/test/java/io/opentracing/contrib/examples/multiple_callbacks/TestMultipleCallbacks.java
+++ b/src/test/java/io/opentracing/contrib/examples/multiple_callbacks/TestMultipleCallbacks.java
@@ -1,48 +1,48 @@
-package io.opentracing.contrib.examples.multiple_callbacks;
-
-import static com.jayway.awaitility.Awaitility.await;
-import static io.opentracing.contrib.examples.TestUtils.reportedSpansSize;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import io.opentracing.Scope;
-import io.opentracing.mock.MockSpan;
-import io.opentracing.mock.MockTracer;
-import io.opentracing.mock.MockTracer.Propagator;
-import io.opentracing.usecases.AutoFinishScopeManager;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import org.junit.Test;
-
-public class TestMultipleCallbacks {
-
-  private final MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);
-
-  @Test
-  public void test() throws Exception {
-    tracer.setScopeManager(new AutoFinishScopeManager());
-
-    Client client = new Client(tracer);
-    try (Scope scope = tracer.buildSpan("parent").startActive()) {
-      client.send("task1", scope, 300);
-      client.send("task2", scope, 200);
-      client.send("task3", scope, 100);
-    }
-
-    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(4));
-
-    List<MockSpan> spans = tracer.finishedSpans();
-    assertEquals(4, spans.size());
-    assertEquals("parent", spans.get(3).operationName());
-
-    MockSpan parentSpan = spans.get(3);
-    for (int i = 0; i < 3; i++) {
-      assertEquals(true, parentSpan.finishMicros() >= spans.get(i).finishMicros());
-      assertEquals(parentSpan.context().traceId(), spans.get(i).context().traceId());
-      assertEquals(parentSpan.context().spanId(), spans.get(i).parentId());
-    }
-
-    assertNull(tracer.scopeManager().active());
-  }
-}
+//package io.opentracing.contrib.examples.multiple_callbacks;
+//
+//import static com.jayway.awaitility.Awaitility.await;
+//import static io.opentracing.contrib.examples.TestUtils.reportedSpansSize;
+//import static org.hamcrest.core.IsEqual.equalTo;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertNull;
+//
+//import io.opentracing.Scope;
+//import io.opentracing.mock.MockSpan;
+//import io.opentracing.mock.MockTracer;
+//import io.opentracing.mock.MockTracer.Propagator;
+//import io.opentracing.usecases.AutoFinishScopeManager;
+//import java.util.List;
+//import java.util.concurrent.TimeUnit;
+//import org.junit.Test;
+//
+//public class TestMultipleCallbacks {
+//
+//  private final MockTracer tracer = new MockTracer(Propagator.TEXT_MAP);
+//
+//  @Test
+//  public void test() throws Exception {
+//    tracer.setScopeManager(new AutoFinishScopeManager());
+//
+//    Client client = new Client(tracer);
+//    try (Scope scope = tracer.buildSpan("parent").startActive()) {
+//      client.send("task1", scope, 300);
+//      client.send("task2", scope, 200);
+//      client.send("task3", scope, 100);
+//    }
+//
+//    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(tracer), equalTo(4));
+//
+//    List<MockSpan> spans = tracer.finishedSpans();
+//    assertEquals(4, spans.size());
+//    assertEquals("parent", spans.get(3).operationName());
+//
+//    MockSpan parentSpan = spans.get(3);
+//    for (int i = 0; i < 3; i++) {
+//      assertEquals(true, parentSpan.finishMicros() >= spans.get(i).finishMicros());
+//      assertEquals(parentSpan.context().traceId(), spans.get(i).context().traceId());
+//      assertEquals(parentSpan.context().spanId(), spans.get(i).parentId());
+//    }
+//
+//    assertNull(tracer.scopeManager().active());
+//  }
+//}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/RequestContext.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/RequestContext.java
@@ -1,0 +1,60 @@
+package io.opentracing.contrib.examples.request_context;
+
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A baggage-like context, but can hold any type of value and it not propagated outside of the process.
+ * <p>
+ * There are few ways to implement this. The main issue is how to kep track of the relation between context map and
+ * a Span when Spans have no identity guaranteed by the API. I see following options:
+ * 1. Wrap ActiveSpanSource, maybe also ActiveSpan/Span and provide identity
+ * 2. Wrap Span and store the context inside it
+ * <p>
+ * If we go with 1. then we as well can do 2., so this implements the 2nd approach.
+ * <p>
+ * Both approaches (adding context map or identity to span) have a drawback though - we will need to downcast to our
+ * WrappedSpan. If the span is wrapped with another wrapper the casting will fail.
+ * <p>
+ * But! That's not all. We need to obtain our current (active) WrappedSpan. But ActiveSpan does not provide such method.
+ * So we also need to wrap ActiveSpan to add a method returning the span :(
+ */
+public class RequestContext {
+    private final Tracer tracer;
+
+    public RequestContext(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public <T> T get(String key, Class<T> valueClass) {
+        Map<String, Object> context = getContext();
+        if (context == null) {
+            return null;
+        }
+
+        //noinspection unchecked
+        return (T) context.get(key);
+    }
+
+    public void put(String key, Object value) {
+        Map<String, Object> context = getContext();
+        if (context != null) {
+            context.put(key, value);
+        }
+    }
+
+    private Map<String, Object> getContext() {
+        Scope scope = tracer.scopeManager().active();
+        if (scope != null) {
+            // !! this works with only our span wrapper, other wrappers will break it
+            WrappedSpan wrapped = (WrappedSpan) scope.span();
+            return wrapped.getRequestContext();
+        }
+        return null;
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/RequestContextTest.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/RequestContextTest.java
@@ -1,0 +1,116 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RequestContextTest {
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    private Tracer createTracer() {
+        MockTracer mockTracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+        mockTracer.setScopeManager(new ThreadLocalScopeManager());
+        return new TracerWrapper(mockTracer);
+    }
+    @Test
+    public void singleSpan() {
+        Tracer tracer = createTracer();
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (Scope scope = tracer.buildSpan("x").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            User user = ctx.get("current_user", User.class);
+
+            assertEquals("john", user.name);
+        }
+    }
+
+    @Test
+    public void propagatesToChildSpans() {
+        Tracer tracer = createTracer();
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (Scope parent = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            try (Scope child = tracer.buildSpan("child")
+                    .asChildOf(parent.span()) // explicit because MockTracer does not add this automatically
+                    .startActive()) {
+                User user = ctx.get("current_user", User.class);
+
+                assertEquals("john", user.name);
+            }
+        }
+    }
+
+    @Test
+    public void changesInChildSpansDoNotAlterParent() {
+        Tracer tracer = createTracer();
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (Scope parent = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            try (Scope child = tracer.buildSpan("child").startActive()) {
+                ctx.put("current_user", new User(2, "bob"));
+            }
+
+            assertEquals(ctx.get("current_user", User.class).name, "john");
+        }
+    }
+
+    @Test
+    public void keysSetInChildNotVisibleInParent() {
+        Tracer tracer = createTracer();
+        RequestContext ctx = new RequestContext(tracer);
+
+        try (Scope parent = tracer.buildSpan("parent").startActive()) {
+            try (Scope child = tracer.buildSpan("child").startActive()) {
+                ctx.put("current_user", new User(2, "bob"));
+            }
+            assertNull(ctx.get("current_user", User.class));
+        }
+    }
+
+    @Test
+    public void propagatesToOtherThreads() throws Exception {
+        final Tracer tracer = createTracer();
+        final RequestContext ctx = new RequestContext(tracer);
+        final AtomicReference<User> threadUser = new AtomicReference<>();
+        try (Scope scope = tracer.buildSpan("parent").startActive()) {
+            ctx.put("current_user", new User(1, "john"));
+
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    // instead of Continuations we pass and activate a Span
+                    tracer.scopeManager().activate(scope.span());
+                    User innerUser = ctx.get("current_user", User.class);
+                    threadUser.set(innerUser);
+                }
+            }).get();
+
+            assertEquals(threadUser.get().name, "john");
+        }
+    }
+
+    static class User {
+        int id;
+        String name;
+
+        User(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/SpanBuilderWrapper.java
@@ -1,0 +1,95 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SpanBuilder which creates Spans with RequestContext. Propagates RequestContext from parent span to child.
+ * <p>
+ * Note - it works only when calling asChildOf(BaseSpan). asChildOf(SpanContext) has no way to obtain
+ * parent's RequestContext.
+ */
+public class SpanBuilderWrapper implements Tracer.SpanBuilder {
+    private final Tracer tracer;
+    private final Tracer.SpanBuilder wrapped;
+    private ConcurrentHashMap<String, Object> withRequestContext;
+
+    public SpanBuilderWrapper(Tracer tracer, Tracer.SpanBuilder wrapped) {
+        this.tracer = tracer;
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public Scope startActive() {
+        // We don't delegate startActive so if underlying tracer does something additional - it will be lost
+        return startManual().activate();
+    }
+
+    @Override
+    public Scope startActive(Scope.Observer observer) {
+        return this.wrapped.startManual().activate(observer);
+    }
+
+    @Override
+    public Span startManual() {
+        return new WrappedSpan(tracer, wrapped.startManual(), withRequestContext);
+    }
+
+    @Override
+    @Deprecated
+    public Span start() {
+        return new WrappedSpan(tracer, wrapped.start(), withRequestContext);
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+        wrapped.asChildOf(parent);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(Span parent) {
+        WrappedSpan parentWrapped = (WrappedSpan) parent;
+        // copy request context from parent
+        withRequestContext = new ConcurrentHashMap<>(parentWrapped.getRequestContext());
+        wrapped.asChildOf(parent);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+        wrapped.addReference(referenceType, referencedContext);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder ignoreActiveSpan() {
+        wrapped.ignoreActiveSpan();
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, String value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, boolean value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, Number value) {
+        wrapped.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        wrapped.withStartTimestamp(microseconds);
+        return this;
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/TracerWrapper.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/TracerWrapper.java
@@ -1,0 +1,39 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+public class TracerWrapper implements Tracer {
+    private final Tracer wrapped;
+
+    public TracerWrapper(Tracer wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ScopeManager scopeManager() {
+        return wrapped.scopeManager();
+    }
+
+    @Override
+    public void setScopeManager(ScopeManager scopeManager) {
+        wrapped.setScopeManager(scopeManager);
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilderWrapper(this, wrapped.buildSpan(operationName));
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        wrapped.inject(spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return wrapped.extract(format, carrier);
+    }
+}

--- a/src/test/java/io/opentracing/contrib/examples/request_context/WrappedSpan.java
+++ b/src/test/java/io/opentracing/contrib/examples/request_context/WrappedSpan.java
@@ -1,0 +1,104 @@
+package io.opentracing.contrib.examples.request_context;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WrappedSpan implements Span {
+    private final Span wrapped;
+    private final Tracer tracer;
+    private Map<String, Object> requestContext;
+
+    public WrappedSpan(Tracer tracer, Span wrapped, ConcurrentHashMap<String, Object> requestContext) {
+        this.wrapped = wrapped;
+        this.tracer = tracer;
+        if (requestContext != null) {
+            this.requestContext = requestContext;
+        } else {
+            this.requestContext = new ConcurrentHashMap<>();
+        }
+    }
+
+    public Map<String, Object> getRequestContext() {
+        return requestContext;
+    }
+
+    @Override
+    public Scope activate() {
+        return tracer.scopeManager().activate(this);
+    }
+
+    @Override
+    public Scope activate(Scope.Observer observer) {
+        return tracer.scopeManager().activate(this, observer);
+    }
+
+    @Override
+    public void finish() {
+        wrapped.finish();
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+        wrapped.finish(finishMicros);
+    }
+
+    @Override
+    public SpanContext context() {
+        return wrapped.context();
+    }
+
+    @Override
+    public Span setTag(String key, String value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span setTag(String key, boolean value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span setTag(String key, Number value) {
+        return wrapped.setTag(key, value);
+    }
+
+    @Override
+    public Span log(Map<String, ?> fields) {
+        return wrapped.log(fields);
+    }
+
+    @Override
+    public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+        return wrapped.log(timestampMicroseconds, fields);
+    }
+
+    @Override
+    public Span log(String event) {
+        return wrapped.log(event);
+    }
+
+    @Override
+    public Span log(long timestampMicroseconds, String event) {
+        return wrapped.log(timestampMicroseconds, event);
+    }
+
+    @Override
+    public Span setBaggageItem(String key, String value) {
+        return wrapped.setBaggageItem(key, value);
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return wrapped.getBaggageItem(key);
+    }
+
+    @Override
+    public Span setOperationName(String operationName) {
+        return wrapped.setOperationName(operationName);
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/opentracing-contrib/java-examples/pull/6 but based on Ben's scopes implementation. I commented out the code other examples that do not compile.

This is an attempt to implement request context - a baggage-like construct which:

- is propagated to child spans, but not outside of the process
- is copied when propagating so changes in child spans do not affect values in the parent span
- can hold arbitrary objects, not only strings 

It is simpler than ActiveSpan version. Continuations weren't really needed as the payload is stored inside the span (inside `WrappedSpan`).

@bhs 
I've run into a small issue. The method `Span.activate()` returns a `Scope`. In my wrapped I implemented it was initially like this:
```java
    @Override
    public Scope activate() {
        return wrapped.activate();
    }
```
but what happens is that `wrapped` span calls tracer.scopeManager().activate(this) and unwraps itself - now the ScopeManager has a reference to the "wrapped" object.

So, I changed the implementation to directly express what should happen (and what the actual Span implementation should do):
```java
    @Override
    public Scope activate() {
        return tracer.scopeManager().activate(this);
    }
```

It seems that `Span.activate()` is just a convenience method and to avoid such problems I think it would be good to make it final to avoid such mistakes. There are more such methods which should have fixed implementation:
- `Span.activate()` - implemented as `tracer.scopeManager().activate(this)`
- `Span.activate(Observer)` 
- `SpanBuilder.startActive()` - implemented as `tracer.scopeManager().activate(this.startManual())`
- `SpanBuilder.startActive(Observer)`

But its not possible to create a `final default` method and there are no `default` methods in Java 6-7, so I'd put this requirement into their javadoc, something like:
"This method is equivalent to tracer.scopeManager().activate(this)"

Additionally if a tracer does something more inside those methods then a wrapped will skip such functionality as it has to use the implementation I listed above (to avoid unwrapping)